### PR TITLE
replace glyphicon with font-awesome icon for heading

### DIFF
--- a/vendor/assets/javascripts/markdown.editor.js.erb
+++ b/vendor/assets/javascripts/markdown.editor.js.erb
@@ -1399,7 +1399,7 @@
             buttons.olist = makeButton("wmd-olist-button", "<%= I18n.t('components.markdown_editor.numbered_list.button_title', default: 'Numbered List (Ctrl+O)') %>", "fa fa-list-ol", bindCommand(function (chunk, postProcessing) {
                 this.doList(chunk, postProcessing, true);
             }), group3);
-            buttons.heading = makeButton("wmd-heading-button", "<%= I18n.t('components.markdown_editor.heading.button_title', default: 'Heading (Ctrl+H)') %>", "glyphicon glyphicon-header", bindCommand("doHeading"), group3);
+            buttons.heading = makeButton("wmd-heading-button", "<%= I18n.t('components.markdown_editor.heading.button_title', default: 'Heading (Ctrl+H)') %>", "fa fa-font", bindCommand("doHeading"), group3);
 
             group4 = makeGroup(4);
             buttons.undo = makeButton("wmd-undo-button", "<%= I18n.t('components.markdown_editor.undo.button_title', default: 'Undo (Ctrl+Z)') %>", "fa fa-undo", null, group4);


### PR DESCRIPTION
I was having a glyphicon problem on my project, so I forked the repo in order to make a tiny change. It's also nice to keep the icons consistent I think (either font-awesome or glyph), but feel free to ignore. :ghost: 