### PR TITLE
[#10] Update gem usage in README file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,14 +56,20 @@ Just require it with Sprockets after `pagedown_bootstrap`:
 I like to then use a new [SimpleForm](https://github.com/plataformatec/simple_form) input:
 
     class PagedownInput < SimpleForm::Inputs::TextInput
-      def input
+      def input(wrapper_options)
         out = "<div id=\"wmd-button-bar-#{attribute_name}\"></div>\n"
-        out << "#{@builder.text_area(attribute_name, input_html_options.merge(
-          { :class => 'wmd-input form-control', :id => "wmd-input-#{attribute_name}"})) }"
+        html_options = input_html_options.merge(class: 'wmd-input', id: "wmd-input-#{attribute_name}")
+        out << "#{@builder.text_area(attribute_name, merge_options(html_options, wrapper_options)) }"
         if input_html_options[:preview]
           out << "<div id=\"wmd-preview-#{attribute_name}\" class=\"wmd-preview\"></div>"
         end
         out.html_safe
+      end
+
+      private
+
+      def merge_options(html_opts, wrapper_opts)
+        html_opts.merge(wrapper_opts) { |_key, first, second| first + ' ' + second }
       end
     end
 


### PR DESCRIPTION
When we use the gem with simple_form then we get a warning regarding https://github.com/plataformatec/simple_form/pull/997 described in https://github.com/hughevans/pagedown-bootstrap-rails/issues/10 However, the recommended solution like:
```ruby
def input(wrapper_options)
    @builder.text_field(attribute_name, merge_wrapper_options(input_html_options, wrapper_options))
end
```
Doesn't work properly in our case because wrapper_options hash looks like:
```ruby
{:class=>"form-control"}
```
And input_html_options hash after the merge looks like:
```ruby
{:preview=>true, :rows=>20, :class=>"wmd-input", :placeholder=>nil, :id=>"wmd-input-body"}
```
When we merge these two hashes using `merge_wrapper_options` helper as a result we get 
```ruby
{:preview=>true, :rows=>20, :class=>nil, :placeholder=>nil, :id=>"wmd-input-body"}
```
As you can see `class` key is a nil but we need both recent values, so:
```ruby
  def merge_options(html_opts, wrapper_opts)
    html_opts.merge(wrapper_opts) { |_key, first, second| first + ' ' + second }
  end
```
seems to work pretty well.