### PR TITLE
Update markdown.extra.js

### DIFF
--- a/pagedown-bootstrap-rails.gemspec
+++ b/pagedown-bootstrap-rails.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.date = Time.now.strftime('%Y-%m-%d')
   s.require_paths = ['lib']
   s.add_dependency('railties', '> 3.1')
-  s.files = Dir['{lib,vendor}/**/*'] + ['Readme.md']
+  s.files = Dir['{lib,vendor}/**/*'] + ['README.md']
   s.homepage = 'http://github.com/hughevans/pagedown-bootstrap-rails'
   s.license = 'MIT'
 end

--- a/vendor/assets/javascripts/markdown.extra.js
+++ b/vendor/assets/javascripts/markdown.extra.js
@@ -16,7 +16,7 @@
      *****************************************************************/
 
     // patch for ie7
-    if (!Array.indexOf) {
+    if (!Array.prototype.indexOf) {
         Array.prototype.indexOf = function(obj) {
             for (var i = 0; i < this.length; i++) {
                 if (this[i] == obj) {


### PR DESCRIPTION
This fixes a Crash in Chrome, see https://github.com/plotly/plotly.js/issues/1192